### PR TITLE
Eliminate reference to `Attribute` interface in amp-toolbox-php which changed namespace

### DIFF
--- a/inc/class-amp-carousel-sanitizer.php
+++ b/inc/class-amp-carousel-sanitizer.php
@@ -27,7 +27,6 @@
 namespace Google\Gutenberg_Bento;
 
 use AmpProject\Dom\Element;
-use AmpProject\Attribute;
 use AMP_Base_Sanitizer;
 
 /**
@@ -47,11 +46,11 @@ class AMP_Carousel_Sanitizer extends AMP_Base_Sanitizer {
 
 		/* @var Element $carousel */
 		foreach ( $carousels as $carousel ) {
-			$carousel->setAttribute( Attribute::LAYOUT, 'responsive' );
+			$carousel->setAttribute( 'layout', 'responsive' );
 
 			// Same 4:1 aspect ratio as in view.css.
-			$carousel->setAttribute( Attribute::WIDTH, '4' );
-			$carousel->setAttribute( Attribute::HEIGHT, '1' );
+			$carousel->setAttribute( 'width', '4' );
+			$carousel->setAttribute( 'height', '1' );
 
 			$carousel_id = $this->dom->getElementId( $carousel, 'wp-block-gutenberg-bento-carousel' );
 
@@ -61,12 +60,12 @@ class AMP_Carousel_Sanitizer extends AMP_Base_Sanitizer {
 			// Allow controlling the carousel using amp-bind similar to how carousel.view.js does.
 			$prev_button = $this->dom->xpath->query( './/button[ contains( @class, "gutenberg-bento-carousel-buttons__prev" ) ]', $wrapper )->item( 0 );
 			if ( $prev_button instanceof Element ) {
-				$prev_button->setAttribute( Attribute::ON, "tap:$carousel_id.prev()" );
+				$prev_button->addAmpAction( 'tap', "$carousel_id.prev()" );
 			}
 
 			$next_button = $this->dom->xpath->query( './/button[ contains( @class, "gutenberg-bento-carousel-buttons__next" ) ]', $wrapper )->item( 0 );
 			if ( $next_button instanceof Element ) {
-				$next_button->setAttribute( Attribute::ON, "tap:$carousel_id.next()" );
+				$next_button->addAmpAction( 'tap', "$carousel_id.next()" );
 			}
 		}
 	}


### PR DESCRIPTION
When testing this with AMP plugin in the `develop` branch, I started getting errors:

```
#1 /app/public/content/plugins/amp/includes/class-amp-theme-support.php(2035): AMP_Content_Sanitizer::sanitize_document(Object(AmpProject\Dom\Document), Array, Array)
#2 /app/public/content/plugins/amp/includes/class-amp-theme-support.php(1753): AMP_Theme_Support::prepare_response('<!doctype html>...')
#3 [internal function]: AMP_Theme_Support::finish_output_buffering('<!doctype html>...', 9)
#4 /app/public/core-dev/src/wp-includes/functions.php(5175): ob_end_flush()
#5 /app/public/core-dev/src/wp-includes/class-wp-hook.php(303): wp_ob_end_flush_all('')
#6 /app/public/core-dev/src/wp-includes/class-wp-hook.php(327): WP_Hook->apply_filters('', Array)
#7 /app/public/core-dev/src/wp-includes/plugin.php(470): WP_Hook->do_action(Array)
#8 /app/public/core-dev/src/wp-includes/load.php(1100): do_action('shutdown')
#9 [internal function]: shutdown_action_hook()
#10 {main}
```

The reason is that amp-toolbox-php [v0.9.0](https://github.com/ampproject/amp-toolbox-php/releases/tag/0.9.0) changed the namespace for the `Attribute` interface from `AmpProject` to `AmpProject\Html` in https://github.com/ampproject/amp-toolbox-php/commit/d3f86d2a081c48fd5236b3b98af2a6e2780f962f, and the AMP plugin updates to that version in https://github.com/ampproject/amp-wp/pull/6756. /cc @schlessera

This PR also improves the setting of the `on` attribute by using the `addAmpAction` method.